### PR TITLE
chore(codeowners): remove file with only an unresolvable cross-org team ref

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,0 @@
-# CODEOWNERS syntax https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
-#
-# Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.
-# Code owners are not automatically requested to review draft pull requests
-# When you mark a draft pull request as ready for review, code owners are automatically notified.
-
-* @squareup/cash-commerce-ios
-


### PR DESCRIPTION
## Summary

The single CODEOWNERS rule references `@squareup/cash-commerce-ios` — a team that exists in the `squareup` GitHub org, not in `cashapp`. GitHub CODEOWNERS only resolves teams in the same org as the repository, so this rule has never produced auto-assigned reviewers from this `cashapp/` repo.

This PR removes the file. Effective ownership behavior is unchanged (no auto-assignment either before or after); we simply stop carrying a broken reference.